### PR TITLE
コメントのJavaScriptの修正

### DIFF
--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,3 +1,4 @@
 $('#comment-post-<%= @post.id.to_s %>').
   html('<%= j render "posts/comment_list", { post: @post } %>');
-$('#comment-form-post-<%= @post.id.to_s %> #comment_comment').val("");
+$('input[type="text"]').val('');
+$('.card-right-comment').animate({ scrollTop: $('.card-right-comment')[0].scrollHeight});

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -103,7 +103,6 @@
             <div class="modal-content">
               <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span class="close-btn" aria-hidden="true">&times;</span></button>
               <div class="modal-body">
-                
                 <div class="col-md-10 col-md-offset-1 mx-auto postShow-wrap">
                   <div class="row post-wrap">
                     <div class="col-md-8">


### PR DESCRIPTION
#What
コメントをしてもコメント内容が消えない点を修正。

#Why
コメントができたら入力欄からコメントが消えた方がわかりやすい為。